### PR TITLE
fix md5 check

### DIFF
--- a/nominatim-docker-entrypoint.sh
+++ b/nominatim-docker-entrypoint.sh
@@ -96,7 +96,7 @@ if [ "$1" == "nominatim-initdb" ]; then
 			curl -L -z /data/"$OSM_PBF" -o /data/"$OSM_PBF" "$OSM_PBF_URL"
 			curl -o /data/"$OSM_PBF".md5 "$OSM_PBF_URL".md5
 			cd /data && \
-				md5sum -c "$OSM_PBF".md5 || rm -f /data/"$OSM_PBF" && exit 1
+				md5sum -c "$OSM_PBF".md5 || ( rm -f /data/"$OSM_PBF" && exit 1 )
 		fi
 		REINITDB=1
 	fi


### PR DESCRIPTION
MD5 check for the downloaded PBF always failed because `&&` and `||` have
the SAME precedence, so `exit 1` was executed even if `md5sum` succeeded.