### PR TITLE
Fix HTTP 500s from nominatim due to missing settings-frontend.php

### DIFF
--- a/12/nominatim-docker-entrypoint.sh
+++ b/12/nominatim-docker-entrypoint.sh
@@ -146,7 +146,7 @@ if [ "$SUBCOMMAND" = "nominatim-initdb" ]; then
   if ! $(echo "SELECT 'tables already created' FROM pg_catalog.pg_tables where tablename = 'country_osm_grid'" |
     gosu $POSTGRES_USER psql nominatim | grep -q 'tables already created') ||
     [ "$REINITDB" ] || [ -f "/data/nominatim-REINITDB" ] || [ "$REDOWNLOAD" ]; then
-    log "$SUBCOMMAND downlowding wikipedia and country files"
+    log "$SUBCOMMAND downloading wikipedia and country files"
     rm -f "/data/nomintaim-REINITDB"
     for file in wikimedia-importance.sql.gz country_grid.sql.gz wikipedia_article.sql.bin wikipedia_redirect.sql.bin gb_postcode_data.sql.gz; do
       download_nominatim_data "$file" || {

--- a/12/nominatim-docker-entrypoint.sh
+++ b/12/nominatim-docker-entrypoint.sh
@@ -85,6 +85,10 @@ cat <>/Nominatim/build/logpipe 1>&2 &
 if [ "$SUBCOMMAND" = "nominatim-apache2" ]; then
   log "$SUBCOMMAND called"
 
+  # generates settings/settings-frontend.php
+  cd /Nominatim/build &&
+    php ./utils/setup.php --setup-website
+
   . /etc/apache2/envvars
 
   if [ ! -z "$APACHE_LOG_DIR" ]; then
@@ -92,11 +96,6 @@ if [ "$SUBCOMMAND" = "nominatim-apache2" ]; then
       ln -sf /dev/stdout access.log &&
       ln -sf /dev/stdout error.log
   fi
-
-  # Not sure where settings.php comes from, but `php utils/setup.php --setup-website`
-  # expects settings-frontend.php otherwise requests to nominatim respond with HTTP 500
-  cd /Nominatim/build/settings &&
-    ln -s settings.php settings-frontend.php
 
   cd /
 

--- a/12/nominatim-docker-entrypoint.sh
+++ b/12/nominatim-docker-entrypoint.sh
@@ -93,6 +93,11 @@ if [ "$SUBCOMMAND" = "nominatim-apache2" ]; then
       ln -sf /dev/stdout error.log
   fi
 
+  # Not sure where settings.php comes from, but `php utils/setup.php --setup-website`
+  # expects settings-frontend.php otherwise requests to nominatim respond with HTTP 500
+  cd /Nominatim/build/settings &&
+    ln -s settings.php settings-frontend.php
+
   cd /
 
   mkdir -p "$APACHE_RUN_DIR" &&


### PR DESCRIPTION
Fixes nominatim returning HTTP 500s after a clean room setup of https://github.com/chesty/maps-docker-compose. 

**Steps to reproduce**
1. git clone https://github.com/chesty/maps-docker-compose
2. cd maps-docker-compose && docker-compose up
3. Wait a while for everything to initialize
4. Navigate to `http://<server>:8080/`
5. Type "hospital" in to the "Start" field and press enter. No search results appear.
6. Observe a HTTP 500 log line in the `docker-compose logs nominatim-apache` output

There is probably a better way to fix this (just rename settings.php to settings-frontend.php) but I don't know enough about the setup to make that change with confidence.

**Testing Done**
1. Rebuilt image and re-ran with the change yielded search results and no more HTTP 500s

