### PR TITLE
Add us_postcode_data.sql.gz so search by zipcode works

### DIFF
--- a/12/nominatim-docker-entrypoint.sh
+++ b/12/nominatim-docker-entrypoint.sh
@@ -148,7 +148,7 @@ if [ "$SUBCOMMAND" = "nominatim-initdb" ]; then
     [ "$REINITDB" ] || [ -f "/data/nominatim-REINITDB" ] || [ "$REDOWNLOAD" ]; then
     log "$SUBCOMMAND downloading wikipedia and country files"
     rm -f "/data/nomintaim-REINITDB"
-    for file in wikimedia-importance.sql.gz country_grid.sql.gz wikipedia_article.sql.bin wikipedia_redirect.sql.bin gb_postcode_data.sql.gz; do
+    for file in wikimedia-importance.sql.gz country_grid.sql.gz wikipedia_article.sql.bin wikipedia_redirect.sql.bin gb_postcode_data.sql.gz us_postcode_data.sql.gz; do
       download_nominatim_data "$file" || {
         touch "/data/nominatim-REINITDB"
         log "$SUBCOMMAND error downloading wikipedia data, exit 2"


### PR DESCRIPTION
This is prompted by a warning during initialization:
```
nominatim-initdb_1    | 2020-09-12 20:14:54 == WARNING: optional external US postcode table file (/Nominatim/data/us_postcode_data.sql.gz) not found. Skipping.
```
A quick look at the file size shows it is only 756k (gb postcodes is 35MB for comparison - https://www.nominatim.org/data/ ) so it shouldn't have too much of an impact on initialization time.
